### PR TITLE
Valikossa olevan lopetuskomennon nimen vaihto (OhTu vko6/teht. 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,3 @@ Testikattavuusraportti muodostuu polkuun `build/reports/jacoco/test`
 - [Sprint1 backlog](https://github.com/ConcernedHobbit/lukuvinkkikirjasto/projects/2)
 - [Sprint2 backlog](https://github.com/ConcernedHobbit/lukuvinkkikirjasto/projects/3)
 - [Burndown](https://github.com/ConcernedHobbit/github-projects-burndown-chart/blob/main/src/github_projects_burndown_chart/charts/lukuvinkkikirjasto-latest.png)
-

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Testikattavuusraportti muodostuu polkuun `build/reports/jacoco/test`
 - [Sprint1 backlog](https://github.com/ConcernedHobbit/lukuvinkkikirjasto/projects/2)
 - [Sprint2 backlog](https://github.com/ConcernedHobbit/lukuvinkkikirjasto/projects/3)
 - [Burndown](https://github.com/ConcernedHobbit/github-projects-burndown-chart/blob/main/src/github_projects_burndown_chart/charts/lukuvinkkikirjasto-latest.png)
+

--- a/doc/Usermanual.md
+++ b/doc/Usermanual.md
@@ -37,4 +37,4 @@ Vinkkejä voi selata valitsemalla 2) Selaa vinkkeja
 
 ## Sovelluksesta poistuminen
 
-Käyttäjä voi poistua sovelluksesta valitsemalla 4) Sulje valikko
+Käyttäjä voi poistua sovelluksesta valitsemalla 4) Lopeta

--- a/src/main/java/kirjasto/TextUserInterface.java
+++ b/src/main/java/kirjasto/TextUserInterface.java
@@ -140,7 +140,7 @@ public class TextUserInterface {
                 "1) Lisaa vinkki \n" +
                 "2) Selaa vinkkeja \n" +
                 "3) Poista vinkki \n" +
-                "4) Sulje valikko\n" +
+                "4) Lopeta\n" +
                 "5) Avaa vinkki (ID)\n" +
                 "7) Hae tagilla vinkkei\n" +
                 "8) Lisää tagi existing vinkille");


### PR DESCRIPTION
Vaihdoin sovelluksen lopetuskomennon nimen/kuvauksen valikossa arvosta 'Sulje valikko' arvoon 'Lopeta'. Mielestäni 'lopeta' on siinä mielessä selkeämpi, että tällöin käy selväksi, että koko ohjelman suoritus lopetetaan, eikä vain pelkästään suljeta valikkoa.